### PR TITLE
Preserve the arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ function Tap(callback, options) {
     if (!e1.touches || e1.touches.length > 1) return
 
     var el = this
+    var args = arguments
 
     var timeout_id = setTimeout(cleanup, timeout)
 
@@ -70,7 +71,8 @@ function Tap(callback, options) {
 
       // calls the handler with the `end` event,
       // but i don't think it matters.
-      callback.call(el, e2)
+      args[0] = e2
+      callback.apply(el, args)
     }
 
     // cleanup end events


### PR DESCRIPTION
Sometimes I need additional arguments pass to the handler, 
eg:

``` js
events.bind('touchstart .sort-asc', 'sort', 'asc')
events.bind('touchstart .sort-dsc', 'sort', 'dsc')
```
